### PR TITLE
Fix an exception reading struct tag and adjust a return type.

### DIFF
--- a/src/etherip/types/CIPData.java
+++ b/src/etherip/types/CIPData.java
@@ -158,16 +158,7 @@ final public class CIPData
             return (short) (this.data.capacity() / this.type.element_size);
         case STRUCT:
         {
-            final Type el_type = Type.forCode(this.data.getShort(0));
-            if (el_type == Type.STRUCT_STRING)
-            {
-                return 1;
-            }
-            else
-            {
-                throw new Exception("Structure elements of type " + this.type
-                        + " not handled");
-            }
+            return 1; // We do not know without byte packing details but at least 1. 
         }
         default:
             throw new Exception("Type " + this.type + " not handled");

--- a/src/etherip/types/CNPath.java
+++ b/src/etherip/types/CNPath.java
@@ -79,8 +79,8 @@ abstract public class CNPath implements Protocol
      *            Name of the tag to put into symbol path
      * @return {@link CNPath}
      */
-    public static CNPath Symbol(final String name)
+    public static CNSymbolPath Symbol(final String path)
     {
-        return new CNSymbolPath(name);
+        return new CNSymbolPath(path);
     }
 }


### PR DESCRIPTION
Fix an exception reading a struct tag during the determineElementCount() called in constructor.

Adjust the class to reflect the real class returned by the static CNPath.Symbol() method.