### PR TITLE
Add synchronisez to execute method

### DIFF
--- a/src/etherip/protocol/CIPReadDataProtocol.java
+++ b/src/etherip/protocol/CIPReadDataProtocol.java
@@ -32,7 +32,7 @@ public class CIPReadDataProtocol extends ProtocolAdapter
     }
 
     /**
-     * Create a read protocol message that reqeusts one or more elements if request is an array
+     * Create a read protocol message that requests one or more elements if request is an array
      *
      * @param count
      */
@@ -53,7 +53,7 @@ public class CIPReadDataProtocol extends ProtocolAdapter
         buf.putShort(this.count); // elements
         if (log != null)
         {
-            log.append("USINT elements          : 1\n");
+            log.append("USINT elements          : ").append(this.count).append("\n");
         }
     }
 

--- a/src/etherip/protocol/Connection.java
+++ b/src/etherip/protocol/Connection.java
@@ -115,7 +115,7 @@ public abstract class Connection implements AutoCloseable
      * @throws Exception
      *             on error
      */
-    public void execute(final Protocol protocol) throws Exception
+    public synchronized void execute(final Protocol protocol) throws Exception
     {
         this.write(protocol);
         this.read(protocol);


### PR DESCRIPTION
To make sure responses are read before another write is done by another thread.

Fix a typo in comment and a missing attribute in CIPReadDataProtocol::toString.