### PR TITLE
Removed lambda. Added synchronized.

### DIFF
--- a/src/etherip/protocol/Transaction.java
+++ b/src/etherip/protocol/Transaction.java
@@ -24,17 +24,17 @@ import java.util.concurrent.atomic.AtomicLong;
 @SuppressWarnings("nls")
 public class Transaction
 {
-    private static final AtomicLong transaction = new AtomicLong(0);
-
+    // SYNC on access
+    private static long transaction;
     static long nextTransaction()
     {
-        return transaction.accumulateAndGet(1, (value, plus) ->
+        synchronized(Transaction.class)
         {
-            long result = value + plus;
-            if (result > 0xffffffffL)
-                return 1;
-            return result;
-        });
+            ++transaction;
+            if (transaction > 0xffffffffL)
+                transaction = 1;
+            return transaction;
+        }
     }
 
     static byte[] format(final long transaction)


### PR DESCRIPTION
Following [issue#24](https://github.com/EPICSTools/etherip/issues/24#issuecomment-421345429) discussion. Transaction class lambda was removed, and modified to accommodate for Java 1.7

I've also checked, and project still fully compatible with Java 1.8
Existing Transaction Test was also verified with below output:

Results with 20 iterations:

```
4294967286
4294967287
4294967288
4294967289
4294967290
4294967291
4294967292
4294967293
4294967294
4294967295
1
2
3
4
5
6
7
8
9
10
```